### PR TITLE
Fix bcrypt version to resolve CI test failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ supabase
 email-validator
 uvicorn
 dotenv
-bcrypt
+bcrypt==4.2.0


### PR DESCRIPTION
Pin bcrypt to version 4.2.0 to fix the 72-byte password limit error that occurs during bcrypt's internal initialization in CI environment.

This resolves the ValueError: password cannot be longer than 72 bytes error in test_login.py tests that was causing CI failures on main branch while passing in PR tests due to environment differences.

